### PR TITLE
feat: Add RSpec tests for Profile model

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -19,7 +19,7 @@ class Building < ApplicationRecord
   MAX_LEVEL = 5
 
   BUILDING_STATS = {
- 'castle' => {
+    'castle' => {
       1 => { cost: { wood: 100, stone: 80, metal: 50 }, max_troops_for_attack: 250 },
       2 => { cost: { wood: 250, stone: 200, metal: 120 }, max_troops_for_attack: 500 },
       3 => { cost: { wood: 600, stone: 550, metal: 300 }, max_troops_for_attack: 1000 },

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     level { 1 }
     association :profile
     association :plot
+
+    trait :barrack do
+      building_type { "barrack" }
+    end
   end
 end

--- a/spec/factories/equipment_items.rb
+++ b/spec/factories/equipment_items.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :equipment_item do
+    sequence(:name) { |n| "Sword of Testing #{n}" }
+    equipment_type { "sword" }
+    attack { 10 }
+    defense { 5 }
+    speed_bonus { 0 }
+    price_in_steps { 100 }
+  end
+end

--- a/spec/factories/equipments.rb
+++ b/spec/factories/equipments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :equipment do
+    association :profile
+    association :equipment_item
+  end
+end

--- a/spec/factories/troops.rb
+++ b/spec/factories/troops.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :troop do
+    troop_type { "swordsman" }
+    level { 1 }
+    attack { 10 }
+    defense { 10 }
+    speed { 5 }
+
+    association :building
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -177,4 +177,50 @@ RSpec.describe Profile, type: :model do
       expect(profile.reload.total_attack).to eq(expected_attack)
     end
   end
+
+  describe '#total_defense' do
+    it 'return base defense' do
+      profile = create(:profile)
+      expect(profile.total_defense).to eq(Profile::DEFAULT_DEFENSE)
+    end
+
+    it 'adds the equipment defense bonus to the default defense' do
+      profile = create(:profile)
+      sword = create(:equipment_item, defense: 20)
+      create(:equipment, profile: profile, equipment_item: sword)
+
+      expected_defense = Profile::DEFAULT_DEFENSE + sword.defense
+      expect(profile.total_defense).to eq(expected_defense)
+    end
+
+    it 'adds troop defense bonus to the default defense' do
+      profile = create(:profile)
+      barracks = create(:building, :barrack, profile: profile)
+
+      troop1 = create(:troop, building: barracks, troop_type: 'swordsman', level: 3)
+      troop2 = create(:troop, building: barracks, troop_type: 'archer', level: 2)
+
+      troop1.reload
+      troop2.reload
+
+      expected_defense = Profile::DEFAULT_DEFENSE + troop1.defense + troop2.defense
+      expect(profile.reload.total_defense).to eq(expected_defense)
+    end
+
+    it 'put base defense, equip defense and troop defense all together' do
+      profile = create(:profile)
+      sword = create(:equipment_item, defense: 20)
+      create(:equipment, profile: profile, equipment_item: sword)
+      barracks = create(:building, :barrack, profile: profile)
+
+      troop1 = create(:troop, building: barracks, troop_type: 'swordsman', level: 3)
+      troop2 = create(:troop, building: barracks, troop_type: 'archer', level: 2)
+
+      troop1.reload
+      troop2.reload
+
+      expected_defense = Profile::DEFAULT_DEFENSE + sword.defense + troop1.defense + troop2.defense
+      expect(profile.reload.total_defense).to eq(expected_defense)
+    end
+  end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -132,7 +132,49 @@ RSpec.describe Profile, type: :model do
     end
   end
 
-  describe 'validations' do
-    
+  describe '#total_attack' do
+    it 'return base attack' do
+      profile = create(:profile)
+      expect(profile.total_attack).to eq(Profile::DEFAULT_ATTACK)
+    end
+
+    it 'adds the equipment attack bonus to the default attack' do
+      profile = create(:profile)
+      sword = create(:equipment_item, attack: 20)
+      create(:equipment, profile: profile, equipment_item: sword)
+
+      expected_attack = Profile::DEFAULT_ATTACK + sword.attack
+      expect(profile.total_attack).to eq(expected_attack)
+    end
+
+    it 'adds troop attack bonus to the default attack' do
+      profile = create(:profile)
+      barracks = create(:building, :barrack, profile: profile)
+
+      troop1 = create(:troop, building: barracks, troop_type: 'swordsman', level: 3)
+      troop2 = create(:troop, building: barracks, troop_type: 'archer', level: 2)
+
+      troop1.reload
+      troop2.reload
+
+      expected_attack = Profile::DEFAULT_ATTACK + troop1.attack + troop2.attack
+      expect(profile.reload.total_attack).to eq(expected_attack)
+    end
+
+    it 'put base attack, equip attack and troop attack all together' do
+      profile = create(:profile)
+      sword = create(:equipment_item, attack: 20)
+      create(:equipment, profile: profile, equipment_item: sword)
+      barracks = create(:building, :barrack, profile: profile)
+
+      troop1 = create(:troop, building: barracks, troop_type: 'swordsman', level: 3)
+      troop2 = create(:troop, building: barracks, troop_type: 'archer', level: 2)
+
+      troop1.reload
+      troop2.reload
+
+      expected_attack = Profile::DEFAULT_ATTACK + sword.attack + troop1.attack + troop2.attack
+      expect(profile.reload.total_attack).to eq(expected_attack)
+    end
   end
 end


### PR DESCRIPTION
### What does this PR do?

This PR expands the test suite for the `Profile` model by adding complete test coverage for the `#total_attack` and `#total_defense` instance methods.

This ensures that the core combat stat calculations are behaving as expected under various conditions.

### Key Changes:
- [x] Added tests for `#total_attack`, covering scenarios with:
    - Base stats only (no bonuses)
    - Equipment bonuses
    - Troop bonuses
    - A combination of all bonuses
- [x] Added an identical set of tests for the `#total_defense` method.
- [x] Created new factories for `Troop`, `EquipmentItem`, and `Equipment` to support these test cases.

### How to test?

1.  Check out this branch.
2.  Run `bundle exec rspec`.
3.  Confirm that all 39 examples pass without failures.